### PR TITLE
fix(ui): harden workflow edges - anomaly guard, safe histogram/density

### DIFF
--- a/src/main/java/net/seninp/grammarviz/view/GrammarVizView.java
+++ b/src/main/java/net/seninp/grammarviz/view/GrammarVizView.java
@@ -759,11 +759,13 @@ public class GrammarVizView implements GrammarVizListener, ActionListener {
       rulesPeriodicityPane.clear();
       anomaliesPane.clear();
       frame.repaint();
-      disableAllButtons();
-      selectFileButton.setEnabled(true);
-      dataLoadButton.setEnabled(true);
-      guessParametersButton.setEnabled(true);
-      discretizeButton.setEnabled(true);
+      if (!workflowBusy.get()) {
+        disableAllButtons();
+        selectFileButton.setEnabled(true);
+        dataLoadButton.setEnabled(true);
+        guessParametersButton.setEnabled(true);
+        discretizeButton.setEnabled(true);
+      }
 
       this.isTimeSeriesLoaded = true;
       this.controller.getSession().chartData = null;
@@ -795,7 +797,9 @@ public class GrammarVizView implements GrammarVizListener, ActionListener {
       //
       anomaliesPane.setChartData(this.controller.getSession());
 
-      enableAllButtons();
+      if (!workflowBusy.get()) {
+        enableAllButtons();
+      }
       // dataChartPane.getChart().setNotify(true);
       frame.revalidate();
       frame.repaint();
@@ -820,7 +824,8 @@ public class GrammarVizView implements GrammarVizListener, ActionListener {
 
   private boolean isWorkflowBlocked() {
     return workflowBusy.get() || dataChartPane.isGuessActive()
-        || (anomalyWorker != null && !anomalyWorker.isDone());
+        || (anomalyWorker != null && !anomalyWorker.isDone()
+            && anomalyWorkerChartData == controller.getSession().chartData); // NOPMD - reference identity: block only when the live search targets the current chart
   }
 
   private boolean tryBeginLongOperation() {
@@ -1206,10 +1211,12 @@ public class GrammarVizView implements GrammarVizListener, ActionListener {
           return;
         }
 
+        final GrammarVizChartData chartData = this.controller.getSession().chartData;
+
         new SwingWorker<Void, Void>() {
           @Override
           protected Void doInBackground() throws Exception {
-            controller.getSession().chartData.performRulePruning();
+            chartData.performRulePruning();
             return null;
           }
 
@@ -1217,6 +1224,9 @@ public class GrammarVizView implements GrammarVizListener, ActionListener {
           protected void done() {
             try {
               get();
+              if (chartData != controller.getSession().chartData) { // NOPMD - reference identity
+                return;
+              }
 
               // setting the chart first
               //

--- a/src/main/java/net/seninp/grammarviz/view/GrammarvizChartPanel.java
+++ b/src/main/java/net/seninp/grammarviz/view/GrammarvizChartPanel.java
@@ -505,19 +505,21 @@ public class GrammarvizChartPanel extends JPanel
   }
 
   private void saveRuleDensityCurve(int[] coverageArray) {
-    // write down the coverage array
-    //
-    try {
-      String filename = session.ruleDensityOutputFileName;
+    final int[] snapshot = Arrays.copyOf(coverageArray, coverageArray.length);
+    final String filename = session.ruleDensityOutputFileName;
+    Thread writer = new Thread(() -> {
       try (BufferedWriter bw = new BufferedWriter(new FileWriter(new File(filename)))) {
-        for (int c : coverageArray) {
+        for (int c : snapshot) {
           bw.write(String.valueOf(c) + "\n");
         }
+        LOGGER.info("rule coverage file written: " + filename);
       }
-    }
-    catch (IOException e) {
-      LOGGER.error("error while writing the rule coverage file", e);
-    }
+      catch (IOException e) {
+        LOGGER.error("error while writing the rule coverage file", e);
+      }
+    }, "rule-density-writer");
+    writer.setDaemon(true);
+    writer.start();
   }
 
   private void displayRulesLengthHistogram() {
@@ -540,6 +542,19 @@ public class GrammarvizChartPanel extends JPanel
       for (RuleInterval interval : r.getRuleIntervals()) {
         allRules.add(interval.getLength());
       }
+    }
+
+    if (allRules.isEmpty()) {
+      TitledBorder tb = (TitledBorder) this.getBorder();
+      tb.setTitle(LABEL_DEFAULT);
+      revalidate();
+      repaint();
+      LOGGER.info("no rules to histogram (empty or R0-only grammar)");
+      SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(this,
+          "No rules to histogram.\n"
+              + "The current grammar has no rules beyond R0 -- try different SAX parameters.",
+          "Nothing to show", JOptionPane.INFORMATION_MESSAGE));
+      return;
     }
 
     // [2.0] make data


### PR DESCRIPTION
## Summary

Small hardening PR from a two-model workflow audit of the GrammarViz GUI, on top of the guesser single-flight and EDT-offload PRs. Five scoped fixes:

- **A [MED]** `isWorkflowBlocked()` is now chart-aware for the anomaly search: it only blocks when the live search targets the session current chart. An orphan search on a chart that was reloaded/re-discretized no longer stalls load/discretize/new searches (restores the intent of bd8cc5c). Entry guard + downstream per-chart "already running" check unchanged.
- **B [MED]** `displayRulesLengthHistogram()` guards an empty / R0-only grammar instead of throwing on the sort/index; logs, resets the panel title, and shows an info dialog.
- **C [MED]** `saveRuleDensityCurve()` writes the coverage file on a named daemon thread from a defensive copy (+ snapshotted filename), keeping large/slow disk writes off the EDT. Same output format.
- **E [LOW]** `PRUNE_RULES` `done()` skips the pane refresh if the chart was replaced mid-prune (mirrors `CLUSTER_RULES`); `endLongOperation()` still restores the UI.
- **F [LOW]** `handleMessage()` no longer re-enables toolbar buttons while a long operation is still in flight; the deferred `endLongOperation()` -> `refreshWorkflowButtons()` sets the final (equivalent) state.

Deliberately out of scope: adding `isWorkflowBlocked()` guards to the read-only viz handlers (would wrongly block density/histogram viewing during an anomaly search; already covered by button disabling + fix F).

## Test plan

- `mvn -Pquality verify` green (PMD + SpotBugs clean, 35 tests pass).
- Orphan anomaly search + reload/discretize: new work no longer blocked.
- Second anomaly on the same chart while one runs: still blocked.
- Rule-length histogram on an empty/R0-only grammar: info dialog, no crash.
- Rule density on a large series: UI stays responsive; coverage file still written.
- Prune while chart replaced: no stale pane refresh; buttons/cursor restored.
