### PR TITLE
ci: drop orphaned SonarCloud job

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -52,32 +52,6 @@ jobs:
         name: codecov-umbrella
         verbose: true
 
-  sonarcloud:
-    name: Build and analyze
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          java-version: 21
-          distribution: temurin
-          cache: maven
-      - name: Install jmotif-sax and jmotif-gi from source
-        run: |
-          git clone --depth 1 https://github.com/jMotif/SAX.git ../SAX
-          git clone --depth 1 https://github.com/jMotif/GI.git ../GI
-          mvn -B install -P single -DskipTests -f ../SAX/pom.xml
-          mvn -B install -DskipTests -f ../GI/pom.xml
-      - name: Build and analyze
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=GrammarViz2_grammarviz2_src
-
   quality:
     name: Static analysis (PMD + SpotBugs)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@ Stack alignment release: no application behavior changes.
 - **JaCoCo** **0.8.13 → 0.8.15** (JDK 25/26); stop excluding the `view` package now
   covered by unit tests (`TestGrammarReductor`, `TestParamsSampler*`).
 - **CI / publish:** clone and `mvn install` SAX + GI from source before build/deploy
-  (until `jmotif-sax` 2.0.1 is on Maven Central); Sonar job uses the same bootstrap.
+  (until `jmotif-sax` 2.0.1 is on Maven Central).
+- **CI:** drop the orphaned SonarCloud "Build and analyze" job (no `SONAR_TOKEN`,
+  no Sonar badge/usage); remove `sonar.*` properties from `pom.xml`.
 
 ### Added
 - README link to [jmotif-conformance](https://github.com/jMotif/jmotif-conformance).

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,6 @@
     <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
     <maven-jacoco-plugin.version>0.8.15</maven-jacoco-plugin.version>
     <gpg.keyname>2EAECBE3B77F5D0A55278EC1B5E0F3D37C8A1537</gpg.keyname>
-    <sonar.organization>grammarviz2</sonar.organization>
-    <sonar.host.url>https://sonarcloud.io</sonar.host.url>    
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Summary

Removes the orphaned SonarCloud **"Build and analyze"** CI job. The project uses no Sonar (no README badge, no gate), the repo has no `SONAR_TOKEN` secret, so the job only ever reported a red `HTTP 403 Forbidden` check on every PR/push. Even with `continue-on-error: true` the individual check stayed red and noisy.

- Drop the `sonarcloud` job from `.github/workflows/maven.yml`.
- Remove the now-unused `sonar.organization` / `sonar.host.url` properties from `pom.xml`.
- Changelog note.

Codecov coverage upload and the PMD + SpotBugs `quality` gate are untouched.

## Test plan

- `mvn -Pquality verify` green locally after the pom change.
- Remaining CI jobs: `build` matrix (macOS/Ubuntu/Windows x JDK 21/25) + `Static analysis (PMD + SpotBugs)`.
